### PR TITLE
Example setup for PropelBundle issue #356

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -35,7 +35,9 @@ framework:
 twig:
     debug:            "%kernel.debug%"
     strict_variables: "%kernel.debug%"
-
+    globals:
+      settings: @app.settings
+      
 # Propel Configuration
 propel:
     logging: "%kernel.debug%"

--- a/app/console
+++ b/app/console
@@ -7,7 +7,7 @@ use Symfony\Component\Debug\Debug;
 
 // if you don't want to setup permissions the proper way, just uncomment the following PHP line
 // read http://symfony.com/doc/current/book/installation.html#configuration-and-setup for more information
-//umask(0000);
+umask(0000);
 
 set_time_limit(0);
 

--- a/src/AppBundle/DependencyInjection/AppExtension.php
+++ b/src/AppBundle/DependencyInjection/AppExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AppBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+/**
+ * This is the class that loads and manages your bundle configuration
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
+ */
+class AppExtension extends Extension
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+    }
+}

--- a/src/AppBundle/DependencyInjection/Configuration.php
+++ b/src/AppBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AppBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * This is the class that validates and merges configuration from your app/config files
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('app');
+
+        // Here you should define the parameters that are allowed to
+        // configure your bundle. See the documentation linked above for
+        // more information on that topic.
+
+        return $treeBuilder;
+    }
+}

--- a/src/AppBundle/Propel/Settings.php
+++ b/src/AppBundle/Propel/Settings.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace AppBundle\Propel;
+
+use AppBundle\Propel\om\BaseSettings;
+
+class Settings extends BaseSettings
+{
+}

--- a/src/AppBundle/Propel/SettingsPeer.php
+++ b/src/AppBundle/Propel/SettingsPeer.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace AppBundle\Propel;
+
+use AppBundle\Propel\om\BaseSettingsPeer;
+
+class SettingsPeer extends BaseSettingsPeer
+{
+}

--- a/src/AppBundle/Propel/SettingsQuery.php
+++ b/src/AppBundle/Propel/SettingsQuery.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace AppBundle\Propel;
+
+use AppBundle\Propel\om\BaseSettingsQuery;
+
+class SettingsQuery extends BaseSettingsQuery
+{
+}

--- a/src/AppBundle/Propel/map/SettingsTableMap.php
+++ b/src/AppBundle/Propel/map/SettingsTableMap.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace AppBundle\Propel\map;
+
+use \RelationMap;
+use \TableMap;
+
+
+/**
+ * This class defines the structure of the 'settings' table.
+ *
+ *
+ *
+ * This map class is used by Propel to do runtime db structure discovery.
+ * For example, the createSelectSql() method checks the type of a given column used in an
+ * ORDER BY clause to know whether it needs to apply SQL to make the ORDER BY case-insensitive
+ * (i.e. if it's a text column type).
+ *
+ * @package    propel.generator.src.AppBundle.Propel.map
+ */
+class SettingsTableMap extends TableMap
+{
+
+    /**
+     * The (dot-path) name of this class
+     */
+    const CLASS_NAME = 'src.AppBundle.Propel.map.SettingsTableMap';
+
+    /**
+     * Initialize the table attributes, columns and validators
+     * Relations are not initialized by this method since they are lazy loaded
+     *
+     * @return void
+     * @throws PropelException
+     */
+    public function initialize()
+    {
+        // attributes
+        $this->setName('settings');
+        $this->setPhpName('Settings');
+        $this->setClassname('AppBundle\\Propel\\Settings');
+        $this->setPackage('src.AppBundle.Propel');
+        $this->setUseIdGenerator(true);
+        // columns
+        $this->addPrimaryKey('id', 'Id', 'INTEGER', true, null, null);
+        $this->addColumn('key', 'Key', 'VARCHAR', false, 255, null);
+        $this->addColumn('value', 'Value', 'VARCHAR', false, 255, null);
+        // validators
+    } // initialize()
+
+    /**
+     * Build the RelationMap objects for this table relationships
+     */
+    public function buildRelations()
+    {
+    } // buildRelations()
+
+} // SettingsTableMap

--- a/src/AppBundle/Propel/om/BaseSettings.php
+++ b/src/AppBundle/Propel/om/BaseSettings.php
@@ -1,0 +1,814 @@
+<?php
+
+namespace AppBundle\Propel\om;
+
+use \BaseObject;
+use \BasePeer;
+use \Criteria;
+use \Exception;
+use \PDO;
+use \Persistent;
+use \Propel;
+use \PropelException;
+use \PropelPDO;
+use AppBundle\Propel\Settings;
+use AppBundle\Propel\SettingsPeer;
+use AppBundle\Propel\SettingsQuery;
+
+abstract class BaseSettings extends BaseObject implements Persistent
+{
+    /**
+     * Peer class name
+     */
+    const PEER = 'AppBundle\\Propel\\SettingsPeer';
+
+    /**
+     * The Peer class.
+     * Instance provides a convenient way of calling static methods on a class
+     * that calling code may not be able to identify.
+     * @var        SettingsPeer
+     */
+    protected static $peer;
+
+    /**
+     * The flag var to prevent infinite loop in deep copy
+     * @var       boolean
+     */
+    protected $startCopy = false;
+
+    /**
+     * The value for the id field.
+     * @var        int
+     */
+    protected $id;
+
+    /**
+     * The value for the key field.
+     * @var        string
+     */
+    protected $key;
+
+    /**
+     * The value for the value field.
+     * @var        string
+     */
+    protected $value;
+
+    /**
+     * Flag to prevent endless save loop, if this object is referenced
+     * by another object which falls in this transaction.
+     * @var        boolean
+     */
+    protected $alreadyInSave = false;
+
+    /**
+     * Flag to prevent endless validation loop, if this object is referenced
+     * by another object which falls in this transaction.
+     * @var        boolean
+     */
+    protected $alreadyInValidation = false;
+
+    /**
+     * Flag to prevent endless clearAllReferences($deep=true) loop, if this object is referenced
+     * @var        boolean
+     */
+    protected $alreadyInClearAllReferencesDeep = false;
+
+    /**
+     * Get the [id] column value.
+     *
+     * @return int
+     */
+    public function getId()
+    {
+
+        return $this->id;
+    }
+
+    /**
+     * Get the [key] column value.
+     *
+     * @return string
+     */
+    public function getKey()
+    {
+
+        return $this->key;
+    }
+
+    /**
+     * Get the [value] column value.
+     *
+     * @return string
+     */
+    public function getValue()
+    {
+
+        return $this->value;
+    }
+
+    /**
+     * Set the value of [id] column.
+     *
+     * @param  int $v new value
+     * @return Settings The current object (for fluent API support)
+     */
+    public function setId($v)
+    {
+        if ($v !== null && is_numeric($v)) {
+            $v = (int) $v;
+        }
+
+        if ($this->id !== $v) {
+            $this->id = $v;
+            $this->modifiedColumns[] = SettingsPeer::ID;
+        }
+
+
+        return $this;
+    } // setId()
+
+    /**
+     * Set the value of [key] column.
+     *
+     * @param  string $v new value
+     * @return Settings The current object (for fluent API support)
+     */
+    public function setKey($v)
+    {
+        if ($v !== null) {
+            $v = (string) $v;
+        }
+
+        if ($this->key !== $v) {
+            $this->key = $v;
+            $this->modifiedColumns[] = SettingsPeer::KEY;
+        }
+
+
+        return $this;
+    } // setKey()
+
+    /**
+     * Set the value of [value] column.
+     *
+     * @param  string $v new value
+     * @return Settings The current object (for fluent API support)
+     */
+    public function setValue($v)
+    {
+        if ($v !== null) {
+            $v = (string) $v;
+        }
+
+        if ($this->value !== $v) {
+            $this->value = $v;
+            $this->modifiedColumns[] = SettingsPeer::VALUE;
+        }
+
+
+        return $this;
+    } // setValue()
+
+    /**
+     * Indicates whether the columns in this object are only set to default values.
+     *
+     * This method can be used in conjunction with isModified() to indicate whether an object is both
+     * modified _and_ has some values set which are non-default.
+     *
+     * @return boolean Whether the columns in this object are only been set with default values.
+     */
+    public function hasOnlyDefaultValues()
+    {
+        // otherwise, everything was equal, so return true
+        return true;
+    } // hasOnlyDefaultValues()
+
+    /**
+     * Hydrates (populates) the object variables with values from the database resultset.
+     *
+     * An offset (0-based "start column") is specified so that objects can be hydrated
+     * with a subset of the columns in the resultset rows.  This is needed, for example,
+     * for results of JOIN queries where the resultset row includes columns from two or
+     * more tables.
+     *
+     * @param array $row The row returned by PDOStatement->fetch(PDO::FETCH_NUM)
+     * @param int $startcol 0-based offset column which indicates which resultset column to start with.
+     * @param boolean $rehydrate Whether this object is being re-hydrated from the database.
+     * @return int             next starting column
+     * @throws PropelException - Any caught Exception will be rewrapped as a PropelException.
+     */
+    public function hydrate($row, $startcol = 0, $rehydrate = false)
+    {
+        try {
+
+            $this->id = ($row[$startcol + 0] !== null) ? (int) $row[$startcol + 0] : null;
+            $this->key = ($row[$startcol + 1] !== null) ? (string) $row[$startcol + 1] : null;
+            $this->value = ($row[$startcol + 2] !== null) ? (string) $row[$startcol + 2] : null;
+            $this->resetModified();
+
+            $this->setNew(false);
+
+            if ($rehydrate) {
+                $this->ensureConsistency();
+            }
+            $this->postHydrate($row, $startcol, $rehydrate);
+
+            return $startcol + 3; // 3 = SettingsPeer::NUM_HYDRATE_COLUMNS.
+
+        } catch (Exception $e) {
+            throw new PropelException("Error populating Settings object", $e);
+        }
+    }
+
+    /**
+     * Checks and repairs the internal consistency of the object.
+     *
+     * This method is executed after an already-instantiated object is re-hydrated
+     * from the database.  It exists to check any foreign keys to make sure that
+     * the objects related to the current object are correct based on foreign key.
+     *
+     * You can override this method in the stub class, but you should always invoke
+     * the base method from the overridden method (i.e. parent::ensureConsistency()),
+     * in case your model changes.
+     *
+     * @throws PropelException
+     */
+    public function ensureConsistency()
+    {
+
+    } // ensureConsistency
+
+    /**
+     * Reloads this object from datastore based on primary key and (optionally) resets all associated objects.
+     *
+     * This will only work if the object has been saved and has a valid primary key set.
+     *
+     * @param boolean $deep (optional) Whether to also de-associated any related objects.
+     * @param PropelPDO $con (optional) The PropelPDO connection to use.
+     * @return void
+     * @throws PropelException - if this object is deleted, unsaved or doesn't have pk match in db
+     */
+    public function reload($deep = false, PropelPDO $con = null)
+    {
+        if ($this->isDeleted()) {
+            throw new PropelException("Cannot reload a deleted object.");
+        }
+
+        if ($this->isNew()) {
+            throw new PropelException("Cannot reload an unsaved object.");
+        }
+
+        if ($con === null) {
+            $con = Propel::getConnection(SettingsPeer::DATABASE_NAME, Propel::CONNECTION_READ);
+        }
+
+        // We don't need to alter the object instance pool; we're just modifying this instance
+        // already in the pool.
+
+        $stmt = SettingsPeer::doSelectStmt($this->buildPkeyCriteria(), $con);
+        $row = $stmt->fetch(PDO::FETCH_NUM);
+        $stmt->closeCursor();
+        if (!$row) {
+            throw new PropelException('Cannot find matching row in the database to reload object values.');
+        }
+        $this->hydrate($row, 0, true); // rehydrate
+
+        if ($deep) {  // also de-associate any related objects?
+
+        } // if (deep)
+    }
+
+    /**
+     * Removes this object from datastore and sets delete attribute.
+     *
+     * @param PropelPDO $con
+     * @return void
+     * @throws PropelException
+     * @throws Exception
+     * @see        BaseObject::setDeleted()
+     * @see        BaseObject::isDeleted()
+     */
+    public function delete(PropelPDO $con = null)
+    {
+        if ($this->isDeleted()) {
+            throw new PropelException("This object has already been deleted.");
+        }
+
+        if ($con === null) {
+            $con = Propel::getConnection(SettingsPeer::DATABASE_NAME, Propel::CONNECTION_WRITE);
+        }
+
+        $con->beginTransaction();
+        try {
+            $deleteQuery = SettingsQuery::create()
+                ->filterByPrimaryKey($this->getPrimaryKey());
+            $ret = $this->preDelete($con);
+            if ($ret) {
+                $deleteQuery->delete($con);
+                $this->postDelete($con);
+                $con->commit();
+                $this->setDeleted(true);
+            } else {
+                $con->commit();
+            }
+        } catch (Exception $e) {
+            $con->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Persists this object to the database.
+     *
+     * If the object is new, it inserts it; otherwise an update is performed.
+     * All modified related objects will also be persisted in the doSave()
+     * method.  This method wraps all precipitate database operations in a
+     * single transaction.
+     *
+     * @param PropelPDO $con
+     * @return int             The number of rows affected by this insert/update and any referring fk objects' save() operations.
+     * @throws PropelException
+     * @throws Exception
+     * @see        doSave()
+     */
+    public function save(PropelPDO $con = null)
+    {
+        if ($this->isDeleted()) {
+            throw new PropelException("You cannot save an object that has been deleted.");
+        }
+
+        if ($con === null) {
+            $con = Propel::getConnection(SettingsPeer::DATABASE_NAME, Propel::CONNECTION_WRITE);
+        }
+
+        $con->beginTransaction();
+        $isInsert = $this->isNew();
+        try {
+            $ret = $this->preSave($con);
+            if ($isInsert) {
+                $ret = $ret && $this->preInsert($con);
+            } else {
+                $ret = $ret && $this->preUpdate($con);
+            }
+            if ($ret) {
+                $affectedRows = $this->doSave($con);
+                if ($isInsert) {
+                    $this->postInsert($con);
+                } else {
+                    $this->postUpdate($con);
+                }
+                $this->postSave($con);
+                SettingsPeer::addInstanceToPool($this);
+            } else {
+                $affectedRows = 0;
+            }
+            $con->commit();
+
+            return $affectedRows;
+        } catch (Exception $e) {
+            $con->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Performs the work of inserting or updating the row in the database.
+     *
+     * If the object is new, it inserts it; otherwise an update is performed.
+     * All related objects are also updated in this method.
+     *
+     * @param PropelPDO $con
+     * @return int             The number of rows affected by this insert/update and any referring fk objects' save() operations.
+     * @throws PropelException
+     * @see        save()
+     */
+    protected function doSave(PropelPDO $con)
+    {
+        $affectedRows = 0; // initialize var to track total num of affected rows
+        if (!$this->alreadyInSave) {
+            $this->alreadyInSave = true;
+
+            if ($this->isNew() || $this->isModified()) {
+                // persist changes
+                if ($this->isNew()) {
+                    $this->doInsert($con);
+                } else {
+                    $this->doUpdate($con);
+                }
+                $affectedRows += 1;
+                $this->resetModified();
+            }
+
+            $this->alreadyInSave = false;
+
+        }
+
+        return $affectedRows;
+    } // doSave()
+
+    /**
+     * Insert the row in the database.
+     *
+     * @param PropelPDO $con
+     *
+     * @throws PropelException
+     * @see        doSave()
+     */
+    protected function doInsert(PropelPDO $con)
+    {
+        $modifiedColumns = array();
+        $index = 0;
+
+        $this->modifiedColumns[] = SettingsPeer::ID;
+        if (null !== $this->id) {
+            throw new PropelException('Cannot insert a value for auto-increment primary key (' . SettingsPeer::ID . ')');
+        }
+
+         // check the columns in natural order for more readable SQL queries
+        if ($this->isColumnModified(SettingsPeer::ID)) {
+            $modifiedColumns[':p' . $index++]  = '`id`';
+        }
+        if ($this->isColumnModified(SettingsPeer::KEY)) {
+            $modifiedColumns[':p' . $index++]  = '`key`';
+        }
+        if ($this->isColumnModified(SettingsPeer::VALUE)) {
+            $modifiedColumns[':p' . $index++]  = '`value`';
+        }
+
+        $sql = sprintf(
+            'INSERT INTO `settings` (%s) VALUES (%s)',
+            implode(', ', $modifiedColumns),
+            implode(', ', array_keys($modifiedColumns))
+        );
+
+        try {
+            $stmt = $con->prepare($sql);
+            foreach ($modifiedColumns as $identifier => $columnName) {
+                switch ($columnName) {
+                    case '`id`':
+                        $stmt->bindValue($identifier, $this->id, PDO::PARAM_INT);
+                        break;
+                    case '`key`':
+                        $stmt->bindValue($identifier, $this->key, PDO::PARAM_STR);
+                        break;
+                    case '`value`':
+                        $stmt->bindValue($identifier, $this->value, PDO::PARAM_STR);
+                        break;
+                }
+            }
+            $stmt->execute();
+        } catch (Exception $e) {
+            Propel::log($e->getMessage(), Propel::LOG_ERR);
+            throw new PropelException(sprintf('Unable to execute INSERT statement [%s]', $sql), $e);
+        }
+
+        try {
+            $pk = $con->lastInsertId();
+        } catch (Exception $e) {
+            throw new PropelException('Unable to get autoincrement id.', $e);
+        }
+        $this->setId($pk);
+
+        $this->setNew(false);
+    }
+
+    /**
+     * Update the row in the database.
+     *
+     * @param PropelPDO $con
+     *
+     * @see        doSave()
+     */
+    protected function doUpdate(PropelPDO $con)
+    {
+        $selectCriteria = $this->buildPkeyCriteria();
+        $valuesCriteria = $this->buildCriteria();
+        BasePeer::doUpdate($selectCriteria, $valuesCriteria, $con);
+    }
+
+    /**
+     * Retrieves a field from the object by name passed in as a string.
+     *
+     * @param string $name name
+     * @param string $type The type of fieldname the $name is of:
+     *               one of the class type constants BasePeer::TYPE_PHPNAME, BasePeer::TYPE_STUDLYPHPNAME
+     *               BasePeer::TYPE_COLNAME, BasePeer::TYPE_FIELDNAME, BasePeer::TYPE_NUM.
+     *               Defaults to BasePeer::TYPE_PHPNAME
+     * @return mixed Value of field.
+     */
+    public function getByName($name, $type = BasePeer::TYPE_PHPNAME)
+    {
+        $pos = SettingsPeer::translateFieldName($name, $type, BasePeer::TYPE_NUM);
+        $field = $this->getByPosition($pos);
+
+        return $field;
+    }
+
+    /**
+     * Retrieves a field from the object by Position as specified in the xml schema.
+     * Zero-based.
+     *
+     * @param int $pos position in xml schema
+     * @return mixed Value of field at $pos
+     */
+    public function getByPosition($pos)
+    {
+        switch ($pos) {
+            case 0:
+                return $this->getId();
+                break;
+            case 1:
+                return $this->getKey();
+                break;
+            case 2:
+                return $this->getValue();
+                break;
+            default:
+                return null;
+                break;
+        } // switch()
+    }
+
+    /**
+     * Exports the object as an array.
+     *
+     * You can specify the key type of the array by passing one of the class
+     * type constants.
+     *
+     * @param     string  $keyType (optional) One of the class type constants BasePeer::TYPE_PHPNAME, BasePeer::TYPE_STUDLYPHPNAME,
+     *                    BasePeer::TYPE_COLNAME, BasePeer::TYPE_FIELDNAME, BasePeer::TYPE_NUM.
+     *                    Defaults to BasePeer::TYPE_PHPNAME.
+     * @param     boolean $includeLazyLoadColumns (optional) Whether to include lazy loaded columns. Defaults to true.
+     * @param     array $alreadyDumpedObjects List of objects to skip to avoid recursion
+     *
+     * @return array an associative array containing the field names (as keys) and field values
+     */
+    public function toArray($keyType = BasePeer::TYPE_PHPNAME, $includeLazyLoadColumns = true, $alreadyDumpedObjects = array())
+    {
+        if (isset($alreadyDumpedObjects['Settings'][$this->getPrimaryKey()])) {
+            return '*RECURSION*';
+        }
+        $alreadyDumpedObjects['Settings'][$this->getPrimaryKey()] = true;
+        $keys = SettingsPeer::getFieldNames($keyType);
+        $result = array(
+            $keys[0] => $this->getId(),
+            $keys[1] => $this->getKey(),
+            $keys[2] => $this->getValue(),
+        );
+        $virtualColumns = $this->virtualColumns;
+        foreach ($virtualColumns as $key => $virtualColumn) {
+            $result[$key] = $virtualColumn;
+        }
+
+
+        return $result;
+    }
+
+    /**
+     * Sets a field from the object by name passed in as a string.
+     *
+     * @param string $name peer name
+     * @param mixed $value field value
+     * @param string $type The type of fieldname the $name is of:
+     *                     one of the class type constants BasePeer::TYPE_PHPNAME, BasePeer::TYPE_STUDLYPHPNAME
+     *                     BasePeer::TYPE_COLNAME, BasePeer::TYPE_FIELDNAME, BasePeer::TYPE_NUM.
+     *                     Defaults to BasePeer::TYPE_PHPNAME
+     * @return void
+     */
+    public function setByName($name, $value, $type = BasePeer::TYPE_PHPNAME)
+    {
+        $pos = SettingsPeer::translateFieldName($name, $type, BasePeer::TYPE_NUM);
+
+        $this->setByPosition($pos, $value);
+    }
+
+    /**
+     * Sets a field from the object by Position as specified in the xml schema.
+     * Zero-based.
+     *
+     * @param int $pos position in xml schema
+     * @param mixed $value field value
+     * @return void
+     */
+    public function setByPosition($pos, $value)
+    {
+        switch ($pos) {
+            case 0:
+                $this->setId($value);
+                break;
+            case 1:
+                $this->setKey($value);
+                break;
+            case 2:
+                $this->setValue($value);
+                break;
+        } // switch()
+    }
+
+    /**
+     * Populates the object using an array.
+     *
+     * This is particularly useful when populating an object from one of the
+     * request arrays (e.g. $_POST).  This method goes through the column
+     * names, checking to see whether a matching key exists in populated
+     * array. If so the setByName() method is called for that column.
+     *
+     * You can specify the key type of the array by additionally passing one
+     * of the class type constants BasePeer::TYPE_PHPNAME, BasePeer::TYPE_STUDLYPHPNAME,
+     * BasePeer::TYPE_COLNAME, BasePeer::TYPE_FIELDNAME, BasePeer::TYPE_NUM.
+     * The default key type is the column's BasePeer::TYPE_PHPNAME
+     *
+     * @param array  $arr     An array to populate the object from.
+     * @param string $keyType The type of keys the array uses.
+     * @return void
+     */
+    public function fromArray($arr, $keyType = BasePeer::TYPE_PHPNAME)
+    {
+        $keys = SettingsPeer::getFieldNames($keyType);
+
+        if (array_key_exists($keys[0], $arr)) $this->setId($arr[$keys[0]]);
+        if (array_key_exists($keys[1], $arr)) $this->setKey($arr[$keys[1]]);
+        if (array_key_exists($keys[2], $arr)) $this->setValue($arr[$keys[2]]);
+    }
+
+    /**
+     * Build a Criteria object containing the values of all modified columns in this object.
+     *
+     * @return Criteria The Criteria object containing all modified values.
+     */
+    public function buildCriteria()
+    {
+        $criteria = new Criteria(SettingsPeer::DATABASE_NAME);
+
+        if ($this->isColumnModified(SettingsPeer::ID)) $criteria->add(SettingsPeer::ID, $this->id);
+        if ($this->isColumnModified(SettingsPeer::KEY)) $criteria->add(SettingsPeer::KEY, $this->key);
+        if ($this->isColumnModified(SettingsPeer::VALUE)) $criteria->add(SettingsPeer::VALUE, $this->value);
+
+        return $criteria;
+    }
+
+    /**
+     * Builds a Criteria object containing the primary key for this object.
+     *
+     * Unlike buildCriteria() this method includes the primary key values regardless
+     * of whether or not they have been modified.
+     *
+     * @return Criteria The Criteria object containing value(s) for primary key(s).
+     */
+    public function buildPkeyCriteria()
+    {
+        $criteria = new Criteria(SettingsPeer::DATABASE_NAME);
+        $criteria->add(SettingsPeer::ID, $this->id);
+
+        return $criteria;
+    }
+
+    /**
+     * Returns the primary key for this object (row).
+     * @return int
+     */
+    public function getPrimaryKey()
+    {
+        return $this->getId();
+    }
+
+    /**
+     * Generic method to set the primary key (id column).
+     *
+     * @param  int $key Primary key.
+     * @return void
+     */
+    public function setPrimaryKey($key)
+    {
+        $this->setId($key);
+    }
+
+    /**
+     * Returns true if the primary key for this object is null.
+     * @return boolean
+     */
+    public function isPrimaryKeyNull()
+    {
+
+        return null === $this->getId();
+    }
+
+    /**
+     * Sets contents of passed object to values from current object.
+     *
+     * If desired, this method can also make copies of all associated (fkey referrers)
+     * objects.
+     *
+     * @param object $copyObj An object of Settings (or compatible) type.
+     * @param boolean $deepCopy Whether to also copy all rows that refer (by fkey) to the current row.
+     * @param boolean $makeNew Whether to reset autoincrement PKs and make the object new.
+     * @throws PropelException
+     */
+    public function copyInto($copyObj, $deepCopy = false, $makeNew = true)
+    {
+        $copyObj->setKey($this->getKey());
+        $copyObj->setValue($this->getValue());
+        if ($makeNew) {
+            $copyObj->setNew(true);
+            $copyObj->setId(NULL); // this is a auto-increment column, so set to default value
+        }
+    }
+
+    /**
+     * Makes a copy of this object that will be inserted as a new row in table when saved.
+     * It creates a new object filling in the simple attributes, but skipping any primary
+     * keys that are defined for the table.
+     *
+     * If desired, this method can also make copies of all associated (fkey referrers)
+     * objects.
+     *
+     * @param boolean $deepCopy Whether to also copy all rows that refer (by fkey) to the current row.
+     * @return Settings Clone of current object.
+     * @throws PropelException
+     */
+    public function copy($deepCopy = false)
+    {
+        // we use get_class(), because this might be a subclass
+        $clazz = get_class($this);
+        $copyObj = new $clazz();
+        $this->copyInto($copyObj, $deepCopy);
+
+        return $copyObj;
+    }
+
+    /**
+     * Returns a peer instance associated with this om.
+     *
+     * Since Peer classes are not to have any instance attributes, this method returns the
+     * same instance for all member of this class. The method could therefore
+     * be static, but this would prevent one from overriding the behavior.
+     *
+     * @return SettingsPeer
+     */
+    public function getPeer()
+    {
+        if (self::$peer === null) {
+            self::$peer = new SettingsPeer();
+        }
+
+        return self::$peer;
+    }
+
+    /**
+     * Clears the current object and sets all attributes to their default values
+     */
+    public function clear()
+    {
+        $this->id = null;
+        $this->key = null;
+        $this->value = null;
+        $this->alreadyInSave = false;
+        $this->alreadyInValidation = false;
+        $this->alreadyInClearAllReferencesDeep = false;
+        $this->clearAllReferences();
+        $this->resetModified();
+        $this->setNew(true);
+        $this->setDeleted(false);
+    }
+
+    /**
+     * Resets all references to other model objects or collections of model objects.
+     *
+     * This method is a user-space workaround for PHP's inability to garbage collect
+     * objects with circular references (even in PHP 5.3). This is currently necessary
+     * when using Propel in certain daemon or large-volume/high-memory operations.
+     *
+     * @param boolean $deep Whether to also clear the references on all referrer objects.
+     */
+    public function clearAllReferences($deep = false)
+    {
+        if ($deep && !$this->alreadyInClearAllReferencesDeep) {
+            $this->alreadyInClearAllReferencesDeep = true;
+
+            $this->alreadyInClearAllReferencesDeep = false;
+        } // if ($deep)
+
+    }
+
+    /**
+     * return the string representation of this object
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string) $this->exportTo(SettingsPeer::DEFAULT_STRING_FORMAT);
+    }
+
+    /**
+     * return true is the object is in saving state
+     *
+     * @return boolean
+     */
+    public function isAlreadyInSave()
+    {
+        return $this->alreadyInSave;
+    }
+
+}

--- a/src/AppBundle/Propel/om/BaseSettingsPeer.php
+++ b/src/AppBundle/Propel/om/BaseSettingsPeer.php
@@ -1,0 +1,771 @@
+<?php
+
+namespace AppBundle\Propel\om;
+
+use \BasePeer;
+use \Criteria;
+use \PDO;
+use \PDOStatement;
+use \Propel;
+use \PropelException;
+use \PropelPDO;
+use AppBundle\Propel\Settings;
+use AppBundle\Propel\SettingsPeer;
+use AppBundle\Propel\map\SettingsTableMap;
+
+abstract class BaseSettingsPeer
+{
+
+    /** the default database name for this class */
+    const DATABASE_NAME = 'default';
+
+    /** the table name for this class */
+    const TABLE_NAME = 'settings';
+
+    /** the related Propel class for this table */
+    const OM_CLASS = 'AppBundle\\Propel\\Settings';
+
+    /** the related TableMap class for this table */
+    const TM_CLASS = 'AppBundle\\Propel\\map\\SettingsTableMap';
+
+    /** The total number of columns. */
+    const NUM_COLUMNS = 3;
+
+    /** The number of lazy-loaded columns. */
+    const NUM_LAZY_LOAD_COLUMNS = 0;
+
+    /** The number of columns to hydrate (NUM_COLUMNS - NUM_LAZY_LOAD_COLUMNS) */
+    const NUM_HYDRATE_COLUMNS = 3;
+
+    /** the column name for the id field */
+    const ID = 'settings.id';
+
+    /** the column name for the key field */
+    const KEY = 'settings.key';
+
+    /** the column name for the value field */
+    const VALUE = 'settings.value';
+
+    /** The default string format for model objects of the related table **/
+    const DEFAULT_STRING_FORMAT = 'YAML';
+
+    /**
+     * An identity map to hold any loaded instances of Settings objects.
+     * This must be public so that other peer classes can access this when hydrating from JOIN
+     * queries.
+     * @var        array Settings[]
+     */
+    public static $instances = array();
+
+
+    /**
+     * holds an array of fieldnames
+     *
+     * first dimension keys are the type constants
+     * e.g. SettingsPeer::$fieldNames[SettingsPeer::TYPE_PHPNAME][0] = 'Id'
+     */
+    protected static $fieldNames = array (
+        BasePeer::TYPE_PHPNAME => array ('Id', 'Key', 'Value', ),
+        BasePeer::TYPE_STUDLYPHPNAME => array ('id', 'key', 'value', ),
+        BasePeer::TYPE_COLNAME => array (SettingsPeer::ID, SettingsPeer::KEY, SettingsPeer::VALUE, ),
+        BasePeer::TYPE_RAW_COLNAME => array ('ID', 'KEY', 'VALUE', ),
+        BasePeer::TYPE_FIELDNAME => array ('id', 'key', 'value', ),
+        BasePeer::TYPE_NUM => array (0, 1, 2, )
+    );
+
+    /**
+     * holds an array of keys for quick access to the fieldnames array
+     *
+     * first dimension keys are the type constants
+     * e.g. SettingsPeer::$fieldNames[BasePeer::TYPE_PHPNAME]['Id'] = 0
+     */
+    protected static $fieldKeys = array (
+        BasePeer::TYPE_PHPNAME => array ('Id' => 0, 'Key' => 1, 'Value' => 2, ),
+        BasePeer::TYPE_STUDLYPHPNAME => array ('id' => 0, 'key' => 1, 'value' => 2, ),
+        BasePeer::TYPE_COLNAME => array (SettingsPeer::ID => 0, SettingsPeer::KEY => 1, SettingsPeer::VALUE => 2, ),
+        BasePeer::TYPE_RAW_COLNAME => array ('ID' => 0, 'KEY' => 1, 'VALUE' => 2, ),
+        BasePeer::TYPE_FIELDNAME => array ('id' => 0, 'key' => 1, 'value' => 2, ),
+        BasePeer::TYPE_NUM => array (0, 1, 2, )
+    );
+
+    /**
+     * Translates a fieldname to another type
+     *
+     * @param      string $name field name
+     * @param      string $fromType One of the class type constants BasePeer::TYPE_PHPNAME, BasePeer::TYPE_STUDLYPHPNAME
+     *                         BasePeer::TYPE_COLNAME, BasePeer::TYPE_FIELDNAME, BasePeer::TYPE_NUM
+     * @param      string $toType   One of the class type constants
+     * @return string          translated name of the field.
+     * @throws PropelException - if the specified name could not be found in the fieldname mappings.
+     */
+    public static function translateFieldName($name, $fromType, $toType)
+    {
+        $toNames = SettingsPeer::getFieldNames($toType);
+        $key = isset(SettingsPeer::$fieldKeys[$fromType][$name]) ? SettingsPeer::$fieldKeys[$fromType][$name] : null;
+        if ($key === null) {
+            throw new PropelException("'$name' could not be found in the field names of type '$fromType'. These are: " . print_r(SettingsPeer::$fieldKeys[$fromType], true));
+        }
+
+        return $toNames[$key];
+    }
+
+    /**
+     * Returns an array of field names.
+     *
+     * @param      string $type The type of fieldnames to return:
+     *                      One of the class type constants BasePeer::TYPE_PHPNAME, BasePeer::TYPE_STUDLYPHPNAME
+     *                      BasePeer::TYPE_COLNAME, BasePeer::TYPE_FIELDNAME, BasePeer::TYPE_NUM
+     * @return array           A list of field names
+     * @throws PropelException - if the type is not valid.
+     */
+    public static function getFieldNames($type = BasePeer::TYPE_PHPNAME)
+    {
+        if (!array_key_exists($type, SettingsPeer::$fieldNames)) {
+            throw new PropelException('Method getFieldNames() expects the parameter $type to be one of the class constants BasePeer::TYPE_PHPNAME, BasePeer::TYPE_STUDLYPHPNAME, BasePeer::TYPE_COLNAME, BasePeer::TYPE_FIELDNAME, BasePeer::TYPE_NUM. ' . $type . ' was given.');
+        }
+
+        return SettingsPeer::$fieldNames[$type];
+    }
+
+    /**
+     * Convenience method which changes table.column to alias.column.
+     *
+     * Using this method you can maintain SQL abstraction while using column aliases.
+     * <code>
+     *		$c->addAlias("alias1", TablePeer::TABLE_NAME);
+     *		$c->addJoin(TablePeer::alias("alias1", TablePeer::PRIMARY_KEY_COLUMN), TablePeer::PRIMARY_KEY_COLUMN);
+     * </code>
+     * @param      string $alias The alias for the current table.
+     * @param      string $column The column name for current table. (i.e. SettingsPeer::COLUMN_NAME).
+     * @return string
+     */
+    public static function alias($alias, $column)
+    {
+        return str_replace(SettingsPeer::TABLE_NAME.'.', $alias.'.', $column);
+    }
+
+    /**
+     * Add all the columns needed to create a new object.
+     *
+     * Note: any columns that were marked with lazyLoad="true" in the
+     * XML schema will not be added to the select list and only loaded
+     * on demand.
+     *
+     * @param      Criteria $criteria object containing the columns to add.
+     * @param      string   $alias    optional table alias
+     * @throws PropelException Any exceptions caught during processing will be
+     *		 rethrown wrapped into a PropelException.
+     */
+    public static function addSelectColumns(Criteria $criteria, $alias = null)
+    {
+        if (null === $alias) {
+            $criteria->addSelectColumn(SettingsPeer::ID);
+            $criteria->addSelectColumn(SettingsPeer::KEY);
+            $criteria->addSelectColumn(SettingsPeer::VALUE);
+        } else {
+            $criteria->addSelectColumn($alias . '.id');
+            $criteria->addSelectColumn($alias . '.key');
+            $criteria->addSelectColumn($alias . '.value');
+        }
+    }
+
+    /**
+     * Returns the number of rows matching criteria.
+     *
+     * @param      Criteria $criteria
+     * @param      boolean $distinct Whether to select only distinct columns; deprecated: use Criteria->setDistinct() instead.
+     * @param      PropelPDO $con
+     * @return int Number of matching rows.
+     */
+    public static function doCount(Criteria $criteria, $distinct = false, PropelPDO $con = null)
+    {
+        // we may modify criteria, so copy it first
+        $criteria = clone $criteria;
+
+        // We need to set the primary table name, since in the case that there are no WHERE columns
+        // it will be impossible for the BasePeer::createSelectSql() method to determine which
+        // tables go into the FROM clause.
+        $criteria->setPrimaryTableName(SettingsPeer::TABLE_NAME);
+
+        if ($distinct && !in_array(Criteria::DISTINCT, $criteria->getSelectModifiers())) {
+            $criteria->setDistinct();
+        }
+
+        if (!$criteria->hasSelectClause()) {
+            SettingsPeer::addSelectColumns($criteria);
+        }
+
+        $criteria->clearOrderByColumns(); // ORDER BY won't ever affect the count
+        $criteria->setDbName(SettingsPeer::DATABASE_NAME); // Set the correct dbName
+
+        if ($con === null) {
+            $con = Propel::getConnection(SettingsPeer::DATABASE_NAME, Propel::CONNECTION_READ);
+        }
+        // BasePeer returns a PDOStatement
+        $stmt = BasePeer::doCount($criteria, $con);
+
+        if ($row = $stmt->fetch(PDO::FETCH_NUM)) {
+            $count = (int) $row[0];
+        } else {
+            $count = 0; // no rows returned; we infer that means 0 matches.
+        }
+        $stmt->closeCursor();
+
+        return $count;
+    }
+    /**
+     * Selects one object from the DB.
+     *
+     * @param      Criteria $criteria object used to create the SELECT statement.
+     * @param      PropelPDO $con
+     * @return Settings
+     * @throws PropelException Any exceptions caught during processing will be
+     *		 rethrown wrapped into a PropelException.
+     */
+    public static function doSelectOne(Criteria $criteria, PropelPDO $con = null)
+    {
+        $critcopy = clone $criteria;
+        $critcopy->setLimit(1);
+        $objects = SettingsPeer::doSelect($critcopy, $con);
+        if ($objects) {
+            return $objects[0];
+        }
+
+        return null;
+    }
+    /**
+     * Selects several row from the DB.
+     *
+     * @param      Criteria $criteria The Criteria object used to build the SELECT statement.
+     * @param      PropelPDO $con
+     * @return array           Array of selected Objects
+     * @throws PropelException Any exceptions caught during processing will be
+     *		 rethrown wrapped into a PropelException.
+     */
+    public static function doSelect(Criteria $criteria, PropelPDO $con = null)
+    {
+        return SettingsPeer::populateObjects(SettingsPeer::doSelectStmt($criteria, $con));
+    }
+    /**
+     * Prepares the Criteria object and uses the parent doSelect() method to execute a PDOStatement.
+     *
+     * Use this method directly if you want to work with an executed statement directly (for example
+     * to perform your own object hydration).
+     *
+     * @param      Criteria $criteria The Criteria object used to build the SELECT statement.
+     * @param      PropelPDO $con The connection to use
+     * @throws PropelException Any exceptions caught during processing will be
+     *		 rethrown wrapped into a PropelException.
+     * @return PDOStatement The executed PDOStatement object.
+     * @see        BasePeer::doSelect()
+     */
+    public static function doSelectStmt(Criteria $criteria, PropelPDO $con = null)
+    {
+        if ($con === null) {
+            $con = Propel::getConnection(SettingsPeer::DATABASE_NAME, Propel::CONNECTION_READ);
+        }
+
+        if (!$criteria->hasSelectClause()) {
+            $criteria = clone $criteria;
+            SettingsPeer::addSelectColumns($criteria);
+        }
+
+        // Set the correct dbName
+        $criteria->setDbName(SettingsPeer::DATABASE_NAME);
+
+        // BasePeer returns a PDOStatement
+        return BasePeer::doSelect($criteria, $con);
+    }
+    /**
+     * Adds an object to the instance pool.
+     *
+     * Propel keeps cached copies of objects in an instance pool when they are retrieved
+     * from the database.  In some cases -- especially when you override doSelect*()
+     * methods in your stub classes -- you may need to explicitly add objects
+     * to the cache in order to ensure that the same objects are always returned by doSelect*()
+     * and retrieveByPK*() calls.
+     *
+     * @param Settings $obj A Settings object.
+     * @param      string $key (optional) key to use for instance map (for performance boost if key was already calculated externally).
+     */
+    public static function addInstanceToPool($obj, $key = null)
+    {
+        if (Propel::isInstancePoolingEnabled()) {
+            if ($key === null) {
+                $key = (string) $obj->getId();
+            } // if key === null
+            SettingsPeer::$instances[$key] = $obj;
+        }
+    }
+
+    /**
+     * Removes an object from the instance pool.
+     *
+     * Propel keeps cached copies of objects in an instance pool when they are retrieved
+     * from the database.  In some cases -- especially when you override doDelete
+     * methods in your stub classes -- you may need to explicitly remove objects
+     * from the cache in order to prevent returning objects that no longer exist.
+     *
+     * @param      mixed $value A Settings object or a primary key value.
+     *
+     * @return void
+     * @throws PropelException - if the value is invalid.
+     */
+    public static function removeInstanceFromPool($value)
+    {
+        if (Propel::isInstancePoolingEnabled() && $value !== null) {
+            if (is_object($value) && $value instanceof Settings) {
+                $key = (string) $value->getId();
+            } elseif (is_scalar($value)) {
+                // assume we've been passed a primary key
+                $key = (string) $value;
+            } else {
+                $e = new PropelException("Invalid value passed to removeInstanceFromPool().  Expected primary key or Settings object; got " . (is_object($value) ? get_class($value) . ' object.' : var_export($value,true)));
+                throw $e;
+            }
+
+            unset(SettingsPeer::$instances[$key]);
+        }
+    } // removeInstanceFromPool()
+
+    /**
+     * Retrieves a string version of the primary key from the DB resultset row that can be used to uniquely identify a row in this table.
+     *
+     * For tables with a single-column primary key, that simple pkey value will be returned.  For tables with
+     * a multi-column primary key, a serialize()d version of the primary key will be returned.
+     *
+     * @param      string $key The key (@see getPrimaryKeyHash()) for this instance.
+     * @return Settings Found object or null if 1) no instance exists for specified key or 2) instance pooling has been disabled.
+     * @see        getPrimaryKeyHash()
+     */
+    public static function getInstanceFromPool($key)
+    {
+        if (Propel::isInstancePoolingEnabled()) {
+            if (isset(SettingsPeer::$instances[$key])) {
+                return SettingsPeer::$instances[$key];
+            }
+        }
+
+        return null; // just to be explicit
+    }
+
+    /**
+     * Clear the instance pool.
+     *
+     * @return void
+     */
+    public static function clearInstancePool($and_clear_all_references = false)
+    {
+      if ($and_clear_all_references) {
+        foreach (SettingsPeer::$instances as $instance) {
+          $instance->clearAllReferences(true);
+        }
+      }
+        SettingsPeer::$instances = array();
+    }
+
+    /**
+     * Method to invalidate the instance pool of all tables related to settings
+     * by a foreign key with ON DELETE CASCADE
+     */
+    public static function clearRelatedInstancePool()
+    {
+    }
+
+    /**
+     * Retrieves a string version of the primary key from the DB resultset row that can be used to uniquely identify a row in this table.
+     *
+     * For tables with a single-column primary key, that simple pkey value will be returned.  For tables with
+     * a multi-column primary key, a serialize()d version of the primary key will be returned.
+     *
+     * @param      array $row PropelPDO resultset row.
+     * @param      int $startcol The 0-based offset for reading from the resultset row.
+     * @return string A string version of PK or null if the components of primary key in result array are all null.
+     */
+    public static function getPrimaryKeyHashFromRow($row, $startcol = 0)
+    {
+        // If the PK cannot be derived from the row, return null.
+        if ($row[$startcol] === null) {
+            return null;
+        }
+
+        return (string) $row[$startcol];
+    }
+
+    /**
+     * Retrieves the primary key from the DB resultset row
+     * For tables with a single-column primary key, that simple pkey value will be returned.  For tables with
+     * a multi-column primary key, an array of the primary key columns will be returned.
+     *
+     * @param      array $row PropelPDO resultset row.
+     * @param      int $startcol The 0-based offset for reading from the resultset row.
+     * @return mixed The primary key of the row
+     */
+    public static function getPrimaryKeyFromRow($row, $startcol = 0)
+    {
+
+        return (int) $row[$startcol];
+    }
+
+    /**
+     * The returned array will contain objects of the default type or
+     * objects that inherit from the default.
+     *
+     * @throws PropelException Any exceptions caught during processing will be
+     *		 rethrown wrapped into a PropelException.
+     */
+    public static function populateObjects(PDOStatement $stmt)
+    {
+        $results = array();
+
+        // set the class once to avoid overhead in the loop
+        $cls = SettingsPeer::getOMClass();
+        // populate the object(s)
+        while ($row = $stmt->fetch(PDO::FETCH_NUM)) {
+            $key = SettingsPeer::getPrimaryKeyHashFromRow($row, 0);
+            if (null !== ($obj = SettingsPeer::getInstanceFromPool($key))) {
+                // We no longer rehydrate the object, since this can cause data loss.
+                // See http://www.propelorm.org/ticket/509
+                // $obj->hydrate($row, 0, true); // rehydrate
+                $results[] = $obj;
+            } else {
+                $obj = new $cls();
+                $obj->hydrate($row);
+                $results[] = $obj;
+                SettingsPeer::addInstanceToPool($obj, $key);
+            } // if key exists
+        }
+        $stmt->closeCursor();
+
+        return $results;
+    }
+    /**
+     * Populates an object of the default type or an object that inherit from the default.
+     *
+     * @param      array $row PropelPDO resultset row.
+     * @param      int $startcol The 0-based offset for reading from the resultset row.
+     * @throws PropelException Any exceptions caught during processing will be
+     *		 rethrown wrapped into a PropelException.
+     * @return array (Settings object, last column rank)
+     */
+    public static function populateObject($row, $startcol = 0)
+    {
+        $key = SettingsPeer::getPrimaryKeyHashFromRow($row, $startcol);
+        if (null !== ($obj = SettingsPeer::getInstanceFromPool($key))) {
+            // We no longer rehydrate the object, since this can cause data loss.
+            // See http://www.propelorm.org/ticket/509
+            // $obj->hydrate($row, $startcol, true); // rehydrate
+            $col = $startcol + SettingsPeer::NUM_HYDRATE_COLUMNS;
+        } else {
+            $cls = SettingsPeer::OM_CLASS;
+            $obj = new $cls();
+            $col = $obj->hydrate($row, $startcol);
+            SettingsPeer::addInstanceToPool($obj, $key);
+        }
+
+        return array($obj, $col);
+    }
+
+    /**
+     * Returns the TableMap related to this peer.
+     * This method is not needed for general use but a specific application could have a need.
+     * @return TableMap
+     * @throws PropelException Any exceptions caught during processing will be
+     *		 rethrown wrapped into a PropelException.
+     */
+    public static function getTableMap()
+    {
+        return Propel::getDatabaseMap(SettingsPeer::DATABASE_NAME)->getTable(SettingsPeer::TABLE_NAME);
+    }
+
+    /**
+     * Add a TableMap instance to the database for this peer class.
+     */
+    public static function buildTableMap()
+    {
+      $dbMap = Propel::getDatabaseMap(BaseSettingsPeer::DATABASE_NAME);
+      if (!$dbMap->hasTable(BaseSettingsPeer::TABLE_NAME)) {
+        $dbMap->addTableObject(new \AppBundle\Propel\map\SettingsTableMap());
+      }
+    }
+
+    /**
+     * The class that the Peer will make instances of.
+     *
+     *
+     * @return string ClassName
+     */
+    public static function getOMClass($row = 0, $colnum = 0)
+    {
+        return SettingsPeer::OM_CLASS;
+    }
+
+    /**
+     * Performs an INSERT on the database, given a Settings or Criteria object.
+     *
+     * @param      mixed $values Criteria or Settings object containing data that is used to create the INSERT statement.
+     * @param      PropelPDO $con the PropelPDO connection to use
+     * @return mixed           The new primary key.
+     * @throws PropelException Any exceptions caught during processing will be
+     *		 rethrown wrapped into a PropelException.
+     */
+    public static function doInsert($values, PropelPDO $con = null)
+    {
+        if ($con === null) {
+            $con = Propel::getConnection(SettingsPeer::DATABASE_NAME, Propel::CONNECTION_WRITE);
+        }
+
+        if ($values instanceof Criteria) {
+            $criteria = clone $values; // rename for clarity
+        } else {
+            $criteria = $values->buildCriteria(); // build Criteria from Settings object
+        }
+
+        if ($criteria->containsKey(SettingsPeer::ID) && $criteria->keyContainsValue(SettingsPeer::ID) ) {
+            throw new PropelException('Cannot insert a value for auto-increment primary key ('.SettingsPeer::ID.')');
+        }
+
+
+        // Set the correct dbName
+        $criteria->setDbName(SettingsPeer::DATABASE_NAME);
+
+        try {
+            // use transaction because $criteria could contain info
+            // for more than one table (I guess, conceivably)
+            $con->beginTransaction();
+            $pk = BasePeer::doInsert($criteria, $con);
+            $con->commit();
+        } catch (Exception $e) {
+            $con->rollBack();
+            throw $e;
+        }
+
+        return $pk;
+    }
+
+    /**
+     * Performs an UPDATE on the database, given a Settings or Criteria object.
+     *
+     * @param      mixed $values Criteria or Settings object containing data that is used to create the UPDATE statement.
+     * @param      PropelPDO $con The connection to use (specify PropelPDO connection object to exert more control over transactions).
+     * @return int             The number of affected rows (if supported by underlying database driver).
+     * @throws PropelException Any exceptions caught during processing will be
+     *		 rethrown wrapped into a PropelException.
+     */
+    public static function doUpdate($values, PropelPDO $con = null)
+    {
+        if ($con === null) {
+            $con = Propel::getConnection(SettingsPeer::DATABASE_NAME, Propel::CONNECTION_WRITE);
+        }
+
+        $selectCriteria = new Criteria(SettingsPeer::DATABASE_NAME);
+
+        if ($values instanceof Criteria) {
+            $criteria = clone $values; // rename for clarity
+
+            $comparison = $criteria->getComparison(SettingsPeer::ID);
+            $value = $criteria->remove(SettingsPeer::ID);
+            if ($value) {
+                $selectCriteria->add(SettingsPeer::ID, $value, $comparison);
+            } else {
+                $selectCriteria->setPrimaryTableName(SettingsPeer::TABLE_NAME);
+            }
+
+        } else { // $values is Settings object
+            $criteria = $values->buildCriteria(); // gets full criteria
+            $selectCriteria = $values->buildPkeyCriteria(); // gets criteria w/ primary key(s)
+        }
+
+        // set the correct dbName
+        $criteria->setDbName(SettingsPeer::DATABASE_NAME);
+
+        return BasePeer::doUpdate($selectCriteria, $criteria, $con);
+    }
+
+    /**
+     * Deletes all rows from the settings table.
+     *
+     * @param      PropelPDO $con the connection to use
+     * @return int             The number of affected rows (if supported by underlying database driver).
+     * @throws PropelException
+     */
+    public static function doDeleteAll(PropelPDO $con = null)
+    {
+        if ($con === null) {
+            $con = Propel::getConnection(SettingsPeer::DATABASE_NAME, Propel::CONNECTION_WRITE);
+        }
+        $affectedRows = 0; // initialize var to track total num of affected rows
+        try {
+            // use transaction because $criteria could contain info
+            // for more than one table or we could emulating ON DELETE CASCADE, etc.
+            $con->beginTransaction();
+            $affectedRows += BasePeer::doDeleteAll(SettingsPeer::TABLE_NAME, $con, SettingsPeer::DATABASE_NAME);
+            // Because this db requires some delete cascade/set null emulation, we have to
+            // clear the cached instance *after* the emulation has happened (since
+            // instances get re-added by the select statement contained therein).
+            SettingsPeer::clearInstancePool();
+            SettingsPeer::clearRelatedInstancePool();
+            $con->commit();
+
+            return $affectedRows;
+        } catch (Exception $e) {
+            $con->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Performs a DELETE on the database, given a Settings or Criteria object OR a primary key value.
+     *
+     * @param      mixed $values Criteria or Settings object or primary key or array of primary keys
+     *              which is used to create the DELETE statement
+     * @param      PropelPDO $con the connection to use
+     * @return int The number of affected rows (if supported by underlying database driver).  This includes CASCADE-related rows
+     *				if supported by native driver or if emulated using Propel.
+     * @throws PropelException Any exceptions caught during processing will be
+     *		 rethrown wrapped into a PropelException.
+     */
+     public static function doDelete($values, PropelPDO $con = null)
+     {
+        if ($con === null) {
+            $con = Propel::getConnection(SettingsPeer::DATABASE_NAME, Propel::CONNECTION_WRITE);
+        }
+
+        if ($values instanceof Criteria) {
+            // invalidate the cache for all objects of this type, since we have no
+            // way of knowing (without running a query) what objects should be invalidated
+            // from the cache based on this Criteria.
+            SettingsPeer::clearInstancePool();
+            // rename for clarity
+            $criteria = clone $values;
+        } elseif ($values instanceof Settings) { // it's a model object
+            // invalidate the cache for this single object
+            SettingsPeer::removeInstanceFromPool($values);
+            // create criteria based on pk values
+            $criteria = $values->buildPkeyCriteria();
+        } else { // it's a primary key, or an array of pks
+            $criteria = new Criteria(SettingsPeer::DATABASE_NAME);
+            $criteria->add(SettingsPeer::ID, (array) $values, Criteria::IN);
+            // invalidate the cache for this object(s)
+            foreach ((array) $values as $singleval) {
+                SettingsPeer::removeInstanceFromPool($singleval);
+            }
+        }
+
+        // Set the correct dbName
+        $criteria->setDbName(SettingsPeer::DATABASE_NAME);
+
+        $affectedRows = 0; // initialize var to track total num of affected rows
+
+        try {
+            // use transaction because $criteria could contain info
+            // for more than one table or we could emulating ON DELETE CASCADE, etc.
+            $con->beginTransaction();
+
+            $affectedRows += BasePeer::doDelete($criteria, $con);
+            SettingsPeer::clearRelatedInstancePool();
+            $con->commit();
+
+            return $affectedRows;
+        } catch (Exception $e) {
+            $con->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Validates all modified columns of given Settings object.
+     * If parameter $columns is either a single column name or an array of column names
+     * than only those columns are validated.
+     *
+     * NOTICE: This does not apply to primary or foreign keys for now.
+     *
+     * @param Settings $obj The object to validate.
+     * @param      mixed $cols Column name or array of column names.
+     *
+     * @return mixed TRUE if all columns are valid or the error message of the first invalid column.
+     */
+    public static function doValidate($obj, $cols = null)
+    {
+        $columns = array();
+
+        if ($cols) {
+            $dbMap = Propel::getDatabaseMap(SettingsPeer::DATABASE_NAME);
+            $tableMap = $dbMap->getTable(SettingsPeer::TABLE_NAME);
+
+            if (! is_array($cols)) {
+                $cols = array($cols);
+            }
+
+            foreach ($cols as $colName) {
+                if ($tableMap->hasColumn($colName)) {
+                    $get = 'get' . $tableMap->getColumn($colName)->getPhpName();
+                    $columns[$colName] = $obj->$get();
+                }
+            }
+        } else {
+
+        }
+
+        return BasePeer::doValidate(SettingsPeer::DATABASE_NAME, SettingsPeer::TABLE_NAME, $columns);
+    }
+
+    /**
+     * Retrieve a single object by pkey.
+     *
+     * @param int $pk the primary key.
+     * @param      PropelPDO $con the connection to use
+     * @return Settings
+     */
+    public static function retrieveByPK($pk, PropelPDO $con = null)
+    {
+
+        if (null !== ($obj = SettingsPeer::getInstanceFromPool((string) $pk))) {
+            return $obj;
+        }
+
+        if ($con === null) {
+            $con = Propel::getConnection(SettingsPeer::DATABASE_NAME, Propel::CONNECTION_READ);
+        }
+
+        $criteria = new Criteria(SettingsPeer::DATABASE_NAME);
+        $criteria->add(SettingsPeer::ID, $pk);
+
+        $v = SettingsPeer::doSelect($criteria, $con);
+
+        return !empty($v) > 0 ? $v[0] : null;
+    }
+
+    /**
+     * Retrieve multiple objects by pkey.
+     *
+     * @param      array $pks List of primary keys
+     * @param      PropelPDO $con the connection to use
+     * @return Settings[]
+     * @throws PropelException Any exceptions caught during processing will be
+     *		 rethrown wrapped into a PropelException.
+     */
+    public static function retrieveByPKs($pks, PropelPDO $con = null)
+    {
+        if ($con === null) {
+            $con = Propel::getConnection(SettingsPeer::DATABASE_NAME, Propel::CONNECTION_READ);
+        }
+
+        $objs = null;
+        if (empty($pks)) {
+            $objs = array();
+        } else {
+            $criteria = new Criteria(SettingsPeer::DATABASE_NAME);
+            $criteria->add(SettingsPeer::ID, $pks, Criteria::IN);
+            $objs = SettingsPeer::doSelect($criteria, $con);
+        }
+
+        return $objs;
+    }
+
+} // BaseSettingsPeer
+
+// This is the static code needed to register the TableMap for this table with the main Propel class.
+//
+BaseSettingsPeer::buildTableMap();
+

--- a/src/AppBundle/Propel/om/BaseSettingsQuery.php
+++ b/src/AppBundle/Propel/om/BaseSettingsQuery.php
@@ -1,0 +1,349 @@
+<?php
+
+namespace AppBundle\Propel\om;
+
+use \Criteria;
+use \Exception;
+use \ModelCriteria;
+use \PDO;
+use \Propel;
+use \PropelException;
+use \PropelObjectCollection;
+use \PropelPDO;
+use AppBundle\Propel\Settings;
+use AppBundle\Propel\SettingsPeer;
+use AppBundle\Propel\SettingsQuery;
+
+/**
+ * @method SettingsQuery orderById($order = Criteria::ASC) Order by the id column
+ * @method SettingsQuery orderByKey($order = Criteria::ASC) Order by the key column
+ * @method SettingsQuery orderByValue($order = Criteria::ASC) Order by the value column
+ *
+ * @method SettingsQuery groupById() Group by the id column
+ * @method SettingsQuery groupByKey() Group by the key column
+ * @method SettingsQuery groupByValue() Group by the value column
+ *
+ * @method SettingsQuery leftJoin($relation) Adds a LEFT JOIN clause to the query
+ * @method SettingsQuery rightJoin($relation) Adds a RIGHT JOIN clause to the query
+ * @method SettingsQuery innerJoin($relation) Adds a INNER JOIN clause to the query
+ *
+ * @method Settings findOne(PropelPDO $con = null) Return the first Settings matching the query
+ * @method Settings findOneOrCreate(PropelPDO $con = null) Return the first Settings matching the query, or a new Settings object populated from the query conditions when no match is found
+ *
+ * @method Settings findOneByKey(string $key) Return the first Settings filtered by the key column
+ * @method Settings findOneByValue(string $value) Return the first Settings filtered by the value column
+ *
+ * @method array findById(int $id) Return Settings objects filtered by the id column
+ * @method array findByKey(string $key) Return Settings objects filtered by the key column
+ * @method array findByValue(string $value) Return Settings objects filtered by the value column
+ */
+abstract class BaseSettingsQuery extends ModelCriteria
+{
+    /**
+     * Initializes internal state of BaseSettingsQuery object.
+     *
+     * @param     string $dbName The dabase name
+     * @param     string $modelName The phpName of a model, e.g. 'Book'
+     * @param     string $modelAlias The alias for the model in this query, e.g. 'b'
+     */
+    public function __construct($dbName = null, $modelName = null, $modelAlias = null)
+    {
+        if (null === $dbName) {
+            $dbName = 'default';
+        }
+        if (null === $modelName) {
+            $modelName = 'AppBundle\\Propel\\Settings';
+        }
+        parent::__construct($dbName, $modelName, $modelAlias);
+    }
+
+    /**
+     * Returns a new SettingsQuery object.
+     *
+     * @param     string $modelAlias The alias of a model in the query
+     * @param   SettingsQuery|Criteria $criteria Optional Criteria to build the query from
+     *
+     * @return SettingsQuery
+     */
+    public static function create($modelAlias = null, $criteria = null)
+    {
+        if ($criteria instanceof SettingsQuery) {
+            return $criteria;
+        }
+        $query = new SettingsQuery(null, null, $modelAlias);
+
+        if ($criteria instanceof Criteria) {
+            $query->mergeWith($criteria);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Find object by primary key.
+     * Propel uses the instance pool to skip the database if the object exists.
+     * Go fast if the query is untouched.
+     *
+     * <code>
+     * $obj  = $c->findPk(12, $con);
+     * </code>
+     *
+     * @param mixed $key Primary key to use for the query
+     * @param     PropelPDO $con an optional connection object
+     *
+     * @return   Settings|Settings[]|mixed the result, formatted by the current formatter
+     */
+    public function findPk($key, $con = null)
+    {
+        if ($key === null) {
+            return null;
+        }
+        if ((null !== ($obj = SettingsPeer::getInstanceFromPool((string) $key))) && !$this->formatter) {
+            // the object is already in the instance pool
+            return $obj;
+        }
+        if ($con === null) {
+            $con = Propel::getConnection(SettingsPeer::DATABASE_NAME, Propel::CONNECTION_READ);
+        }
+        $this->basePreSelect($con);
+        if ($this->formatter || $this->modelAlias || $this->with || $this->select
+         || $this->selectColumns || $this->asColumns || $this->selectModifiers
+         || $this->map || $this->having || $this->joins) {
+            return $this->findPkComplex($key, $con);
+        } else {
+            return $this->findPkSimple($key, $con);
+        }
+    }
+
+    /**
+     * Alias of findPk to use instance pooling
+     *
+     * @param     mixed $key Primary key to use for the query
+     * @param     PropelPDO $con A connection object
+     *
+     * @return                 Settings A model object, or null if the key is not found
+     * @throws PropelException
+     */
+     public function findOneById($key, $con = null)
+     {
+        return $this->findPk($key, $con);
+     }
+
+    /**
+     * Find object by primary key using raw SQL to go fast.
+     * Bypass doSelect() and the object formatter by using generated code.
+     *
+     * @param     mixed $key Primary key to use for the query
+     * @param     PropelPDO $con A connection object
+     *
+     * @return                 Settings A model object, or null if the key is not found
+     * @throws PropelException
+     */
+    protected function findPkSimple($key, $con)
+    {
+        $sql = 'SELECT `id`, `key`, `value` FROM `settings` WHERE `id` = :p0';
+        try {
+            $stmt = $con->prepare($sql);
+            $stmt->bindValue(':p0', $key, PDO::PARAM_INT);
+            $stmt->execute();
+        } catch (Exception $e) {
+            Propel::log($e->getMessage(), Propel::LOG_ERR);
+            throw new PropelException(sprintf('Unable to execute SELECT statement [%s]', $sql), $e);
+        }
+        $obj = null;
+        if ($row = $stmt->fetch(PDO::FETCH_NUM)) {
+            $obj = new Settings();
+            $obj->hydrate($row);
+            SettingsPeer::addInstanceToPool($obj, (string) $key);
+        }
+        $stmt->closeCursor();
+
+        return $obj;
+    }
+
+    /**
+     * Find object by primary key.
+     *
+     * @param     mixed $key Primary key to use for the query
+     * @param     PropelPDO $con A connection object
+     *
+     * @return Settings|Settings[]|mixed the result, formatted by the current formatter
+     */
+    protected function findPkComplex($key, $con)
+    {
+        // As the query uses a PK condition, no limit(1) is necessary.
+        $criteria = $this->isKeepQuery() ? clone $this : $this;
+        $stmt = $criteria
+            ->filterByPrimaryKey($key)
+            ->doSelect($con);
+
+        return $criteria->getFormatter()->init($criteria)->formatOne($stmt);
+    }
+
+    /**
+     * Find objects by primary key
+     * <code>
+     * $objs = $c->findPks(array(12, 56, 832), $con);
+     * </code>
+     * @param     array $keys Primary keys to use for the query
+     * @param     PropelPDO $con an optional connection object
+     *
+     * @return PropelObjectCollection|Settings[]|mixed the list of results, formatted by the current formatter
+     */
+    public function findPks($keys, $con = null)
+    {
+        if ($con === null) {
+            $con = Propel::getConnection($this->getDbName(), Propel::CONNECTION_READ);
+        }
+        $this->basePreSelect($con);
+        $criteria = $this->isKeepQuery() ? clone $this : $this;
+        $stmt = $criteria
+            ->filterByPrimaryKeys($keys)
+            ->doSelect($con);
+
+        return $criteria->getFormatter()->init($criteria)->format($stmt);
+    }
+
+    /**
+     * Filter the query by primary key
+     *
+     * @param     mixed $key Primary key to use for the query
+     *
+     * @return SettingsQuery The current query, for fluid interface
+     */
+    public function filterByPrimaryKey($key)
+    {
+
+        return $this->addUsingAlias(SettingsPeer::ID, $key, Criteria::EQUAL);
+    }
+
+    /**
+     * Filter the query by a list of primary keys
+     *
+     * @param     array $keys The list of primary key to use for the query
+     *
+     * @return SettingsQuery The current query, for fluid interface
+     */
+    public function filterByPrimaryKeys($keys)
+    {
+
+        return $this->addUsingAlias(SettingsPeer::ID, $keys, Criteria::IN);
+    }
+
+    /**
+     * Filter the query on the id column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterById(1234); // WHERE id = 1234
+     * $query->filterById(array(12, 34)); // WHERE id IN (12, 34)
+     * $query->filterById(array('min' => 12)); // WHERE id >= 12
+     * $query->filterById(array('max' => 12)); // WHERE id <= 12
+     * </code>
+     *
+     * @param     mixed $id The value to use as filter.
+     *              Use scalar values for equality.
+     *              Use array values for in_array() equivalent.
+     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return SettingsQuery The current query, for fluid interface
+     */
+    public function filterById($id = null, $comparison = null)
+    {
+        if (is_array($id)) {
+            $useMinMax = false;
+            if (isset($id['min'])) {
+                $this->addUsingAlias(SettingsPeer::ID, $id['min'], Criteria::GREATER_EQUAL);
+                $useMinMax = true;
+            }
+            if (isset($id['max'])) {
+                $this->addUsingAlias(SettingsPeer::ID, $id['max'], Criteria::LESS_EQUAL);
+                $useMinMax = true;
+            }
+            if ($useMinMax) {
+                return $this;
+            }
+            if (null === $comparison) {
+                $comparison = Criteria::IN;
+            }
+        }
+
+        return $this->addUsingAlias(SettingsPeer::ID, $id, $comparison);
+    }
+
+    /**
+     * Filter the query on the key column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByKey('fooValue');   // WHERE key = 'fooValue'
+     * $query->filterByKey('%fooValue%'); // WHERE key LIKE '%fooValue%'
+     * </code>
+     *
+     * @param     string $key The value to use as filter.
+     *              Accepts wildcards (* and % trigger a LIKE)
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return SettingsQuery The current query, for fluid interface
+     */
+    public function filterByKey($key = null, $comparison = null)
+    {
+        if (null === $comparison) {
+            if (is_array($key)) {
+                $comparison = Criteria::IN;
+            } elseif (preg_match('/[\%\*]/', $key)) {
+                $key = str_replace('*', '%', $key);
+                $comparison = Criteria::LIKE;
+            }
+        }
+
+        return $this->addUsingAlias(SettingsPeer::KEY, $key, $comparison);
+    }
+
+    /**
+     * Filter the query on the value column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByValue('fooValue');   // WHERE value = 'fooValue'
+     * $query->filterByValue('%fooValue%'); // WHERE value LIKE '%fooValue%'
+     * </code>
+     *
+     * @param     string $value The value to use as filter.
+     *              Accepts wildcards (* and % trigger a LIKE)
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return SettingsQuery The current query, for fluid interface
+     */
+    public function filterByValue($value = null, $comparison = null)
+    {
+        if (null === $comparison) {
+            if (is_array($value)) {
+                $comparison = Criteria::IN;
+            } elseif (preg_match('/[\%\*]/', $value)) {
+                $value = str_replace('*', '%', $value);
+                $comparison = Criteria::LIKE;
+            }
+        }
+
+        return $this->addUsingAlias(SettingsPeer::VALUE, $value, $comparison);
+    }
+
+    /**
+     * Exclude object from result
+     *
+     * @param   Settings $settings Object to remove from the list of results
+     *
+     * @return SettingsQuery The current query, for fluid interface
+     */
+    public function prune($settings = null)
+    {
+        if ($settings) {
+            $this->addUsingAlias(SettingsPeer::ID, $settings->getId(), Criteria::NOT_EQUAL);
+        }
+
+        return $this;
+    }
+
+}

--- a/src/AppBundle/Resources/config/schema.xml
+++ b/src/AppBundle/Resources/config/schema.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database name="default" namespace="AppBundle\Propel" defaultIdMethod="native">
+    <table name="settings" phpName="Settings">
+        <column name="id" type="integer" required="true" primaryKey="true" autoIncrement="true" />
+        <column name="key" type="varchar" size="255" />
+        <column name="value" type="varchar" size="255" />
+		<vendor type="mysql">
+			<parameter name="Engine" value="InnoDB"/>
+			<parameter name="Charset" value="utf8"/>
+		</vendor>
+    </table>
+</database>

--- a/src/AppBundle/Resources/config/services.yml
+++ b/src/AppBundle/Resources/config/services.yml
@@ -1,0 +1,6 @@
+parameters:
+
+services:
+    app.settings:
+        class: AppBundle\Services\PropelSettings
+        arguments: []

--- a/src/AppBundle/Services/PropelSettings.php
+++ b/src/AppBundle/Services/PropelSettings.php
@@ -1,0 +1,26 @@
+<?php
+namespace AppBundle\Services;
+
+use AppBundle\Propel\SettingsQuery;
+
+class PropelSettings {
+    private $settings = array();
+    
+    public function __construct() {
+        $this->initialize();
+    }
+    
+    public function initialize() {
+        $settings = SettingsQuery::create()
+            ->select(array('key', 'value'))
+            ->find();
+        
+        foreach ( $settings as $s ) {
+            $this->settigns[$s['key']] = $s['value'];
+        }
+    }
+    
+    public function get($key, $default = null) {
+        return isset($this->settings[$key]) ? $this->settings[$key] : $default;
+    }
+}

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -6,7 +6,7 @@ use Symfony\Component\Debug\Debug;
 // If you don't want to setup permissions the proper way, just uncomment the following PHP line
 // read http://symfony.com/doc/current/book/installation.html#checking-symfony-application-configuration-and-setup
 // for more information
-//umask(0000);
+umask(0000);
 
 // This check prevents access to debug front controllers that are deployed by accident to production servers.
 // Feel free to remove this, extend it, or make something more sophisticated.
@@ -14,8 +14,8 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
     || !(in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1')) || php_sapi_name() === 'cli-server')
 ) {
-    header('HTTP/1.0 403 Forbidden');
-    exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
+    //header('HTTP/1.0 403 Forbidden');
+    //exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }
 
 /**


### PR DESCRIPTION
This is exampel setup for PropelBundle issue [#356](https://github.com/propelorm/PropelBundle/issues/356).

When you migrate database and type
`rm app/cache/* -r && app/console cache:clear`

you will get

>  [PropelException]
>  No connection information in your runtime configuration file for datasource
>   [default]

It seems like propel try to connect to database before it gets configuration. It means Twig service can create instance of any service before PropelBundle configuration is loaded. I had no such problem in symfony before  2.8 version. This is an issue only during symfony cache warmup process.
